### PR TITLE
style compliant to PEP 8 and adjust Import order

### DIFF
--- a/examples/session_callback_example.py
+++ b/examples/session_callback_example.py
@@ -12,10 +12,9 @@ IAudioSessionEvents.OnSessionDisconnected()         Gets called on for example S
 https://docs.microsoft.com/en-us/windows/win32/api/audiopolicy/nn-audiopolicy-iaudiosessionevents
 
 """
-
-from pycaw.pycaw import (AudioUtilities, IAudioSessionEvents)
-from comtypes import COMObject, COMError
 import time
+from comtypes import COMObject, COMError
+from pycaw.pycaw import (AudioUtilities, IAudioSessionEvents)
 
 app_name="msedge.exe"
 
@@ -59,7 +58,7 @@ def add_callback(app_name):
             callback = AudioSessionEvents()
             # Adding the callback by accessing the IAudioSessionControl2 interface through ._ctl
             session._ctl.RegisterAudioSessionNotification(callback)
-            
+
     if not app_found:
         exit("Enter the right 'app_name', start it and play something")
 

--- a/examples/session_callback_example.py
+++ b/examples/session_callback_example.py
@@ -17,9 +17,9 @@ https://docs.microsoft.com/en-us/windows/win32/api/audiopolicy/nn-audiopolicy-ia
 """
 import time
 
-from comtypes import COMObject, COMError
+from comtypes import COMError, COMObject
 
-from pycaw.pycaw import (AudioUtilities, IAudioSessionEvents)
+from pycaw.pycaw import AudioUtilities, IAudioSessionEvents
 
 app_name = "msedge.exe"
 
@@ -74,7 +74,7 @@ def add_callback(app_name):
 
             app_found = True
             callback = AudioSessionEvents()
-            # Adding the callback by accessing the 
+            # Adding the callback by accessing the
             # IAudioSessionControl2 interface through ._ctl
             session._ctl.RegisterAudioSessionNotification(callback)
 

--- a/examples/session_callback_example.py
+++ b/examples/session_callback_example.py
@@ -5,18 +5,23 @@ Then launch this file ;)
 Requirements: Python >= 3.6 - f strings ;)
 
 following "IAudioSessionEvents" callbacks are supported:
-IAudioSessionEvents.OnSimpleVolumeChanged()         Gets called on volume and mute change
-IAudioSessionEvents.OnStateChanged()                Gets called on session state change (active/inactive/expired)
-IAudioSessionEvents.OnSessionDisconnected()         Gets called on for example Speaker unplug
+:: Gets called on volume and mute change:
+IAudioSessionEvents.OnSimpleVolumeChanged()
+:: Gets called on session state change (active/inactive/expired)
+IAudioSessionEvents.OnStateChanged()
+:: Gets called on for example Speaker unplug
+IAudioSessionEvents.OnSessionDisconnected()
 
 https://docs.microsoft.com/en-us/windows/win32/api/audiopolicy/nn-audiopolicy-iaudiosessionevents
 
 """
 import time
+
 from comtypes import COMObject, COMError
+
 from pycaw.pycaw import (AudioUtilities, IAudioSessionEvents)
 
-app_name="msedge.exe"
+app_name = "msedge.exe"
 
 
 class AudioSessionEvents(COMObject):
@@ -25,12 +30,25 @@ class AudioSessionEvents(COMObject):
     def __init__(self):
         # not necessary only to decode the returned int value
         # see mmdeviceapi.h and audiopolicy.h
-        self.AudioSessionState = ["AudioSessionStateInactive", "AudioSessionStateActive", "AudioSessionStateExpired"]
-        self.AudioSessionDisconnectReason = ["DisconnectReasonDeviceRemoval", "DisconnectReasonServerShutdown", "DisconnectReasonFormatChanged", "DisconnectReasonSessionLogoff", "DisconnectReasonSessionDisconnected", "DisconnectReasonExclusiveModeOverride"]
+        self.AudioSessionState = [
+            "AudioSessionStateInactive",
+            "AudioSessionStateActive",
+            "AudioSessionStateExpired"
+        ]
+        self.AudioSessionDisconnectReason = [
+            "DisconnectReasonDeviceRemoval",
+            "DisconnectReasonServerShutdown",
+            "DisconnectReasonFormatChanged",
+            "DisconnectReasonSessionLogoff",
+            "DisconnectReasonSessionDisconnected",
+            "DisconnectReasonExclusiveModeOverride"
+        ]
 
     def OnSimpleVolumeChanged(self, NewVolume, NewMute, EventContext):
         print(':: OnSimpleVolumeChanged callback')
-        print(f"NewVolume: {NewVolume}; NewMute: {NewMute}; EventContext: {EventContext.contents}")
+        print(f"NewVolume: {NewVolume};"
+              "NewMute: {NewMute};"
+              "EventContext: {EventContext.contents}")
 
     def OnStateChanged(self, NewState):
         print(':: OnStateChanged callback')
@@ -52,22 +70,25 @@ def add_callback(app_name):
     # grap the right session
     app_found = False
     for session in sessions:
-        if session.Process and session.Process.name() == app_name: # app_name = "msedge.exe"
+        if session.Process and session.Process.name() == app_name:
 
             app_found = True
             callback = AudioSessionEvents()
-            # Adding the callback by accessing the IAudioSessionControl2 interface through ._ctl
+            # Adding the callback by accessing the 
+            # IAudioSessionControl2 interface through ._ctl
             session._ctl.RegisterAudioSessionNotification(callback)
 
     if not app_found:
         exit("Enter the right 'app_name', start it and play something")
 
     print("Ready to go!")
-    print("Change the volume / mute state / close the app or unplug your speaker")
+    print("Change the volume / mute state"
+          "/ close the app or unplug your speaker")
     print("and watch the callbacks ;)\n")
 
     try:
-        time.sleep(300) # wait 300 seconds for callbacks
+        # wait 300 seconds for callbacks
+        time.sleep(300)
     except KeyboardInterrupt:
         pass
     finally:

--- a/pycaw/pycaw.py
+++ b/pycaw/pycaw.py
@@ -248,9 +248,9 @@ class IAudioSessionEvents(IUnknown):
         # [in] BOOL    NewMute,
         # [in] LPCGUID EventContext);
         COMMETHOD([], HRESULT, 'OnSimpleVolumeChanged',
-            (['in'], c_float, 'NewVolume'),
-            (['in'], BOOL, 'NewMute'),
-            (['in'], POINTER(GUID), 'EventContext')),
+                  (['in'], c_float, 'NewVolume'),
+                  (['in'], BOOL, 'NewMute'),
+                  (['in'], POINTER(GUID), 'EventContext')),
         # HRESULT OnChannelVolumeChanged(
         # [in] DWORD    ChannelCount,
         # [in] float [] NewChannelVolumeArray,
@@ -264,11 +264,11 @@ class IAudioSessionEvents(IUnknown):
         # HRESULT OnStateChanged(
         # AudioSessionState NewState);
         COMMETHOD([], HRESULT, 'OnStateChanged',
-            (['in'], DWORD, 'NewState')),
+                  (['in'], DWORD, 'NewState')),
         # HRESULT OnSessionDisconnected(
         # [in] AudioSessionDisconnectReason DisconnectReason);
         COMMETHOD([], HRESULT, 'OnSessionDisconnected',
-            (['in'], DWORD, 'DisconnectReason')),
+                  (['in'], DWORD, 'DisconnectReason')),
     )
 
 
@@ -299,11 +299,11 @@ class IAudioSessionControl(IUnknown):
         # HRESULT RegisterAudioSessionNotification(
         # [in] IAudioSessionEvents *NewNotifications);
         COMMETHOD([], HRESULT, 'RegisterAudioSessionNotification',
-                 (['in'], POINTER(IAudioSessionEvents), 'NewNotifications')),
+                  (['in'], POINTER(IAudioSessionEvents), 'NewNotifications')),
         # HRESULT UnregisterAudioSessionNotification(
         # [in] IAudioSessionEvents *NewNotifications);
         COMMETHOD([], HRESULT, 'UnregisterAudioSessionNotification',
-                 (['in'], POINTER(IAudioSessionEvents), 'NewNotifications')))
+                  (['in'], POINTER(IAudioSessionEvents), 'NewNotifications')))
 
 
 class IAudioSessionControl2(IAudioSessionControl):


### PR DESCRIPTION
pycaw/pycaw.py and examples/session_callback_example.py now are style compliant to PEP 8.

examples/session_callback_example.py has the right import order